### PR TITLE
[epic:#9/ issue:#12]: 댕글 영상 데이터 수집 및 조회 기능 구현

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -33,5 +33,6 @@ urlpatterns = [
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path("api/v1/integrations/", include("integrations.kto.urls")),
     path("api/v1/integrations/youtube/", include("integrations.youtube.urls")),
+    path("api/v1/daenggle/", include("daenggle.urls")),
 
 ]

--- a/daenggle/serializers.py
+++ b/daenggle/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+class ShortsQuery(serializers.Serializer):
+    type = serializers.ChoiceField(choices=[
+        "trending", "accommodation", "place", "keyword"
+    ])
+    contextId= serializers.CharField(required=False, allow_blank=True, default="")
+    keyword= serializers.CharField(required=False, allow_blank=True, default="")
+    sort= serializers.ChoiceField(choices=["rank", "recent", "views"], default="rank")
+    limit= serializers.IntegerField(min_value=1, max_value=50, default=20)
+    offset= serializers.IntegerField(min_value=0, default=0)  # ← 심플한 페이지네이션
+
+    # 품질 필터(있으면 적용)
+    days= serializers.IntegerField(required=False, min_value=1, max_value=365, default=None)
+    maxDuration= serializers.IntegerField(required=False, min_value=1, max_value=600, default=None)

--- a/daenggle/service/ingest.py
+++ b/daenggle/service/ingest.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
 from django.conf import settings
-from django.db import transaction
+from django.db import transaction, IntegrityError
 from django.utils.dateparse import parse_datetime
 
 from integrations.youtube.client import YouTubeClient
@@ -31,20 +31,35 @@ def _to_int(v):
         return None
 
 @transaction.atomic
-def _upsert_batch(items: List[Dict], *, category: str, keyword: str = "",
-                  context_id: str = "", context_name: str = "",
-                  max_duration_seconds: Optional[int] = 60) -> int:
-
+def _upsert_batch(
+    items: List[Dict],
+    *,
+    category: str,
+    keyword: str = "",
+    context_id: str = "",
+    context_name: str = "",
+    max_duration_seconds: Optional[int] = 60,
+) -> int:
     saved = 0
+    seen = set()  # (video_id, category, context_id)
+
     for it in items:
         vid = it.get("id")
+        if not vid:
+            continue
+
         sn = it.get("snippet", {}) or {}
         cd = it.get("contentDetails", {}) or {}
         st = it.get("statistics", {}) or {}
 
+        key = (vid, category, context_id or "")
+        if key in seen:
+            continue
+        seen.add(key)
+
         dur = iso_to_seconds(cd.get("duration"))
         if max_duration_seconds is not None and dur is not None and dur > max_duration_seconds:
-            continue  # 숏폼 기준 초과는 제외
+            continue
 
         published_at = parse_datetime(sn.get("publishedAt") or "") or datetime.now(timezone.utc)
 
@@ -64,14 +79,28 @@ def _upsert_batch(items: List[Dict], *, category: str, keyword: str = "",
             ),
         )
 
-        DaenggleTag.objects.get_or_create(
-            clip=clip,
-            category=category,
-            keyword=keyword or "",
-            context_id=context_id or "",
-            context_name=context_name or "",
-        )
+        try:
+            tag, created = DaenggleTag.objects.get_or_create(
+                clip=clip,
+                category=category,
+                context_id=context_id or "",
+                defaults={
+                    "keyword": keyword or "",
+                    "context_name": context_name or "",
+                },
+            )
+        except IntegrityError:
+
+            tag = DaenggleTag.objects.get(
+                clip=clip, category=category, context_id=context_id or ""
+            )
+            created = False
+
+        if context_name and tag.context_name != context_name:
+            DaenggleTag.objects.filter(pk=tag.pk).update(context_name=context_name)
+
         saved += 1
+
     return saved
 
 def sync_keywords(
@@ -79,11 +108,12 @@ def sync_keywords(
     *,
     days: int = 60,
     pages: int = 1,
-    max_duration_seconds: Optional[int] = 60,  # ← 여기 기본값만 바꾸면 전체 기본 기준이 바뀜
+    max_duration_seconds: Optional[int] = 60,
     category: str = DaenggleTag.Category.KEYWORD,
     context_id: str = "",
     context_name: str = "",
 ) -> Dict:
+
     client = YouTubeClient()
     published_after = days_ago_rfc3339(days)
 
@@ -92,9 +122,9 @@ def sync_keywords(
     total_saved = 0
 
     for kw in [k.strip() for k in (keywords or []) if k and k.strip()]:
-
         all_ids: List[str] = []
         next_token: Optional[str] = None
+
         for _ in range(max(1, pages)):
             resp = client.search_video_ids(
                 q=kw,
@@ -118,8 +148,9 @@ def sync_keywords(
                 deduped_ids.append(vid)
 
         saved = 0
+
         for i in range(0, len(deduped_ids), 50):
-            batch_ids = deduped_ids[i:i + 50]
+            batch_ids = deduped_ids[i : i + 50]
             details = client.get_videos_details(batch_ids)
             saved += _upsert_batch(
                 details,

--- a/daenggle/service/query.py
+++ b/daenggle/service/query.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from typing import Dict, Optional, List
+from datetime import timedelta
+from django.utils.timezone import now as tz_now
+from django.db.models import Q
+from django.db.models import Count
+from daenggle.models import DaenggleClip, DaenggleTag
+
+def _pick_thumb(clip):
+    t = clip.thumbnails or {}
+    # YouTube가 주는 해상도 우선순위대로 고름
+    for key in ("maxres", "standard", "high", "medium", "default"):
+        url = (t.get(key) or {}).get("url")
+        if url:
+            return url
+    # 그래도 없으면 기본값
+    return f"https://i.ytimg.com/vi/{clip.video_id}/hqdefault.jpg"
+
+def _clip_to_dto(clip) -> Dict:
+    tag_names = [t.context_name for t in getattr(clip, "taggings_all", [])][:10]
+    thumb = _pick_thumb(clip)
+    return {
+        "clipId": clip.id,
+        "videoId": clip.video_id,
+        "title": clip.title,
+        "channelTitle": clip.channel_title,
+        "publishedAt": clip.published_at,
+        "durationSeconds": clip.duration_seconds,
+        "viewCount": clip.view_count,
+        "thumbnailUrl": thumb,
+        "watchUrl": f"https://www.youtube.com/watch?v={clip.video_id}",
+        "tags": tag_names,
+    }
+
+def list_shorts(
+    feed_type: str,
+    *,
+    context_id: Optional[str] = None,
+    keyword: Optional[str] = None,
+    days: Optional[int] = None,
+    max_duration: Optional[int] = None,
+    limit: int = 20,
+    offset: int = 0,
+    sort: str = "rank",
+) -> Dict:
+    qs = DaenggleClip.objects.all()
+
+    if feed_type == "trending":
+        qs = qs.filter(tagging__category=DaenggleTag.Category.TREND)
+
+    elif feed_type == "place":
+        qs = qs.filter(tagging__category=DaenggleTag.Category.PLACE)
+        if context_id:
+            qs = qs.filter(tagging__context_id=context_id)
+
+    elif feed_type == "accommodation":
+        qs = qs.filter(tagging__category=DaenggleTag.Category.ACCOMMODATION)
+        if context_id:
+            qs = qs.filter(tagging__context_id=context_id)
+
+    elif feed_type == "keyword":
+        qs = qs.filter(tagging__category=DaenggleTag.Category.KEYWORD)
+        if keyword:
+            qs = qs.filter(tagging__context_name__iexact=keyword.strip())
+    else:
+        return {"items": [], "nextOffset": None, "hasMore": False}
+
+    qs = qs.distinct()
+
+    if days is not None:
+        qs = qs.filter(published_at__gte=tz_now() - timedelta(days=int(days)))
+    if max_duration is not None:
+        qs = qs.filter(duration_seconds__lte=int(max_duration))
+
+    if sort == "views":
+        qs = qs.order_by("-view_count", "-published_at", "-id")
+    elif sort == "recent":
+        qs = qs.order_by("-published_at", "-view_count", "-id")
+    else:
+        qs = qs.order_by("-published_at", "-view_count", "-id")
+
+    clips = list(qs[offset: offset + limit])
+
+    tag_map: Dict[int, List[str]] = {}
+    rows = (DaenggleTag.objects
+            .filter(clip_id__in=[c.id for c in clips])
+            .values("clip_id", "context_name"))
+    for r in rows:
+        tag_map.setdefault(r["clip_id"], []).append(r["context_name"])
+    for c in clips:
+        c.taggings_all = [SimpleNamespace(context_name=n) for n in tag_map.get(c.id, [])]
+
+    items = [_clip_to_dto(c) for c in clips]
+    next_offset = offset + limit
+    has_more = len(items) == limit
+
+    return {"items": items, "nextOffset": next_offset if has_more else None, "hasMore": has_more}

--- a/daenggle/urls.py
+++ b/daenggle/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import ShortsListView
+
+urlpatterns = [
+    path("shorts", ShortsListView.as_view()),
+]

--- a/daenggle/views.py
+++ b/daenggle/views.py
@@ -1,3 +1,28 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from drf_yasg.utils import swagger_auto_schema
 
-# Create your views here.
+from daenggle.serializers import ShortsQuery
+from daenggle.service.query import list_shorts
+
+class ShortsListView(APIView):
+    @swagger_auto_schema(operation_summary="댕글 숏폼 단일 섹션 조회", tags=["Daenggle"], query_serializer=ShortsQuery)
+    def get(self, request):
+        s = ShortsQuery(data=request.query_params)
+        s.is_valid(raise_exception=True)
+        q = s.validated_data
+
+        if q["type"] == "keyword" and not q.get("keyword"):
+            return Response({"detail": "keyword is required for type=keyword"}, status=400)
+
+        res = list_shorts(
+            q["type"],
+            context_id=q.get("contextId") or None,
+            keyword=q.get("keyword") or None,
+            days=q.get("days"),
+            max_duration=q.get("maxDuration"),
+            limit=q["limit"],
+            offset=q["offset"],
+            sort=q["sort"],
+        )
+        return Response(res)

--- a/integrations/youtube/presets.py
+++ b/integrations/youtube/presets.py
@@ -1,0 +1,28 @@
+
+TRENDING_KEYWORDS = [
+    "제주 반려견 여행", "제주 애견동반", "제주 강아지 여행", "제주 애견카페"
+]
+
+
+PLACE_PRESETS = [
+    {
+        "context_id": "PLACE_aeweol",
+        "context_name": "애월·한림",
+        "keywords": ["애월 애견동반", "한림 반려견", "곽지 강아지", "애월 카페 반려견"]
+    },
+    {
+        "context_id": "PLACE_seongsan",
+        "context_name": "성산·우도",
+        "keywords": ["성산 일출봉 반려견", "우도 강아지 동반", "성산 애견"]
+    },
+    # TODO: 필요한 장소 계속 추가
+]
+
+ACCOM_PRESETS = [
+    {
+        "context_id": "ACC_jeju_001",
+        "context_name": "OO호텔",
+        "keywords": ["제주 애견동반 숙소", "제주 독채 반려견", "펫프렌들리 제주 숙소"]
+    },
+    # TODO: 필요한 숙소 계속 추가
+]

--- a/integrations/youtube/serializers.py
+++ b/integrations/youtube/serializers.py
@@ -12,3 +12,23 @@ class YouTubeSyncRequest(serializers.Serializer):
     )
     contextId = serializers.CharField(required=False, allow_blank=True, default="")
     contextName = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class BatchSyncBody(serializers.Serializer):
+    include = serializers.ListField(
+        child=serializers.ChoiceField(["trending", "place", "accommodation"]),
+        required=False,
+        default=["trending", "place", "accommodation"],
+        help_text="돌릴 대상 선택 (기본: 전부)"
+    )
+    days = serializers.IntegerField(required=False, default=90)
+    pages = serializers.IntegerField(required=False, default=1)
+    maxDuration = serializers.IntegerField(required=False, allow_null=True, default=120)
+
+    # 특정 대상만 선별해서 돌리고 싶을 때(옵션)
+    placeIds = serializers.ListField(
+        child=serializers.CharField(), required=False, default=None
+    )
+    accommodationIds = serializers.ListField(
+        child=serializers.CharField(), required=False, default=None
+    )

--- a/integrations/youtube/urls.py
+++ b/integrations/youtube/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import YouTubeSyncView
+from .views import YouTubeSyncView, YouTubeBatchSyncView
 
 urlpatterns = [
     path("sync", YouTubeSyncView.as_view()),
+    path("sync-batch", YouTubeBatchSyncView.as_view()),
 ]

--- a/integrations/youtube/views.py
+++ b/integrations/youtube/views.py
@@ -3,8 +3,12 @@ from rest_framework.response import Response
 from rest_framework import status
 from drf_yasg.utils import swagger_auto_schema
 
+from .serializers import BatchSyncBody
+from .presets import TRENDING_KEYWORDS, PLACE_PRESETS, ACCOM_PRESETS
 from .serializers import YouTubeSyncRequest
+
 from daenggle.service.ingest import sync_keywords
+from daenggle.models import DaenggleTag
 
 class YouTubeSyncView(APIView):
 
@@ -27,3 +31,90 @@ class YouTubeSyncView(APIView):
         return Response({**result,
                          "limits": {"days": d["days"], "pages": d["pages"], "maxDuration": d["maxDuration"]}},
                         status=status.HTTP_200_OK)
+
+
+class YouTubeBatchSyncView(APIView):
+    @swagger_auto_schema(
+        operation_summary="원클릭 배치 수집(트렌딩/장소/숙소)",
+        tags=["Integration/YouTube"],
+        request_body=BatchSyncBody,
+    )
+    def post(self, request):
+        s = BatchSyncBody(data=request.data or {})
+        s.is_valid(raise_exception=True)
+        q = s.validated_data
+
+        include = set(q["include"])
+        days = q["days"]
+        pages = q["pages"]
+        max_dur = q.get("maxDuration")
+        place_ids = set(q.get("placeIds") or []) or None
+        acc_ids   = set(q.get("accommodationIds") or []) or None
+
+        results = {}
+
+        # 1) 트렌딩(조회수 높은 댕글용 베이스 데이터) — 태그: TREND
+        if "trending" in include:
+            res = sync_keywords(
+                TRENDING_KEYWORDS,
+                days=days,
+                pages=pages,
+                max_duration_seconds=max_dur,
+                category=DaenggleTag.Category.TREND,
+                context_id="", context_name="",
+            )
+            results["trending"] = res
+
+        # 2) 장소별
+        if "place" in include:
+            place_runs = []
+            for p in PLACE_PRESETS:
+                if place_ids and p["context_id"] not in place_ids:
+                    continue
+                place_runs.append(
+                    sync_keywords(
+                        p["keywords"],
+                        days=days,
+                        pages=pages,
+                        max_duration_seconds=max_dur,
+                        category=DaenggleTag.Category.PLACE,
+                        context_id=p["context_id"],
+                        context_name=p["context_name"],
+                    )
+                )
+            results["place"] = place_runs
+
+        # 3) 숙소별
+        if "accommodation" in include:
+            acc_runs = []
+            for a in ACCOM_PRESETS:
+                if acc_ids and a["context_id"] not in acc_ids:
+                    continue
+                acc_runs.append(
+                    sync_keywords(
+                        a["keywords"],
+                        days=days,
+                        pages=pages,
+                        max_duration_seconds=max_dur,
+                        category=DaenggleTag.Category.ACCOMMODATION,
+                        context_id=a["context_id"],
+                        context_name=a["context_name"],
+                    )
+                )
+            results["accommodation"] = acc_runs
+
+
+        summary = {"totalFound": 0, "totalSaved": 0}
+
+        def acc_total(res):
+            if isinstance(res, dict):
+                summary["totalFound"] += res.get("totalFound", 0)
+                summary["totalSaved"] += res.get("totalSaved", 0)
+
+        if "trending" in results:
+            acc_total(results["trending"])
+        for k in ("place", "accommodation"):
+            for r in results.get(k, []):
+                acc_total(r)
+
+        return Response({"summary": summary, "results": results})


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
- 댕글 영상 일괄 수집 API 추가: 트렌딩/장소/숙소 프리셋 기반으로 키워드 검색 → 상세 조회 → DB upsert까지 한 번에 수행
- 댕글 숏폼 조회 API 추가

## 관련 Epic
#9 

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #12 

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- [integrations/youtube] 섹션별(트렌드, 장소, 숙소) 일괄 수집 API 구현
  - POST /api/v1/integrations/youtube/sync-batch
  - include: ["trending","place","accommodation"] 중 선택
- 프리셋/스키마 정비
  - presets.py: 트렌딩/장소/숙소 키워드 세트 정의(컨텍스트 id/name 포함)
  - serializers.py: 요청 스키마(BatchSyncBody) 유효성 검증
- 수집 안정화
  - 중복 video_id 제거, 배치(최대 50개) 상세조회, idempotent upsert

- [daenggle] 댕글 영상 조회 API구현
  - GET /api/v1/daenggle/shorts
  - 트렌드별, 장소별, 숙소별 댕글 영상 조회 가능

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->

