### PR TITLE
[epic:#14/issue:#16]: 로그인 시작 api 구현

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'accounts'

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,0 +1,12 @@
+from django.contrib.auth import get_user_model
+from django.db import models
+
+User = get_user_model()
+
+class SocialAccount(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="socialaccounts")
+    provider = models.CharField(max_length=20)         # Kakao
+    provider_user_id = models.CharField(max_length=64)  # Kakao id
+
+    class Meta:
+        unique_together = ("provider", "provider_user_id")

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import KakaoLoginStartView
+
+urlpatterns = [
+    path("kakao/login", KakaoLoginStartView.as_view()),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,0 +1,29 @@
+import secrets
+from urllib.parse import urlencode
+from django.conf import settings
+from django.shortcuts import redirect
+
+from rest_framework.views import APIView
+from rest_framework.permissions import AllowAny
+from drf_yasg.utils import swagger_auto_schema
+
+class KakaoLoginStartView(APIView):
+    permission_classes = [AllowAny]
+
+    @swagger_auto_schema(
+        operation_summary="카카오 로그인 시작",
+        operation_description="Kakao authorize로 302 리다이렉트합니다.",
+        tags=["Auth"],
+        responses={302: "Redirect to Kakao authorize"},
+        security=[],
+    )
+    def get(self, request):
+        state = secrets.token_urlsafe(16)
+        request.session["kakao_oauth_state"] = state
+        params = {
+            "client_id": settings.KAKAO_REST_API_KEY,
+            "redirect_uri": settings.KAKAO_REDIRECT_URI,
+            "response_type": "code",
+            "state": state,
+        }
+        return redirect(f"https://kauth.kakao.com/oauth/authorize?{urlencode(params)}")

--- a/config/settings.py
+++ b/config/settings.py
@@ -40,8 +40,13 @@ YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY")
 YOUTUBE_REGION_CODE = os.getenv("YOUTUBE_REGION_CODE", "KR")
 YOUTUBE_RELEVANCE_LANG = os.getenv("YOUTUBE_RELEVANCE_LANG", "ko")
 
+KAKAO_REST_API_KEY = os.environ.get("KAKAO_REST_API_KEY")
+KAKAO_REDIRECT_URI = os.environ.get("KAKAO_REDIRECT_URI")
+
 ALLOWED_HOSTS = ["localhost", "0.0.0.0","127.0.0.1"]
 
+SESSION_COOKIE_SAMESITE = "Lax"
+SESSION_COOKIE_HTTPONLY = True
 
 # Application definition
 
@@ -58,6 +63,7 @@ INSTALLED_APPS = [
     'places',
     'integrations',
     'daenggle',
+    'accounts',
 ]
 
 MIDDLEWARE = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -34,5 +34,5 @@ urlpatterns = [
     path("api/v1/integrations/", include("integrations.kto.urls")),
     path("api/v1/integrations/youtube/", include("integrations.youtube.urls")),
     path("api/v1/daenggle/", include("daenggle.urls")),
-
+    path("api/v1/auth/", include("accounts.urls")),
 ]


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
- 카카오 로그인 시작 API 구현

## 관련 Epic
epic: #14 

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
 #16 

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- KakaoLoginStartView(APIView) 구현
- 세션에 kakao_oauth_state 생성/저장
