### PR TITLE
[epic:#14/issue:#15]: 카카오 로그인 콜백 처리 api 구현 및 로그인 된 사용자 api 구현

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,10 +1,8 @@
-from django.contrib.auth import get_user_model
+from django.conf import settings
 from django.db import models
 
-User = get_user_model()
-
 class SocialAccount(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="socialaccounts")
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="socialaccounts")
     provider = models.CharField(max_length=20)         # Kakao
     provider_user_id = models.CharField(max_length=64)  # Kakao id
 

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
-from .views import KakaoLoginStartView
+from .views import KakaoLoginStartView,KakaoCallbackView,MeView
 
 urlpatterns = [
     path("kakao/login", KakaoLoginStartView.as_view()),
+    path("kakao/callback", KakaoCallbackView.as_view()),
+    path("me", MeView.as_view()),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,11 +1,26 @@
 import secrets
+import requests
+
 from urllib.parse import urlencode
 from django.conf import settings
+from drf_yasg import openapi
+from django.contrib.auth import get_user_model, login
+from django.db import transaction
 from django.shortcuts import redirect
-
 from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 from drf_yasg.utils import swagger_auto_schema
+from .models import SocialAccount
+from rest_framework.permissions import IsAuthenticated
+
+User = get_user_model()
+
+code_param  = openapi.Parameter("code",  openapi.IN_QUERY, type=openapi.TYPE_STRING, required=False)
+state_param = openapi.Parameter("state", openapi.IN_QUERY, type=openapi.TYPE_STRING, required=False)
+err_param   = openapi.Parameter("error", openapi.IN_QUERY, type=openapi.TYPE_STRING, required=False)
+err_desc    = openapi.Parameter("error_description", openapi.IN_QUERY, type=openapi.TYPE_STRING, required=False)
+
 
 class KakaoLoginStartView(APIView):
     permission_classes = [AllowAny]
@@ -27,3 +42,93 @@ class KakaoLoginStartView(APIView):
             "state": state,
         }
         return redirect(f"https://kauth.kakao.com/oauth/authorize?{urlencode(params)}")
+
+
+class KakaoCallbackView(APIView):
+    permission_classes = [AllowAny]
+
+    @swagger_auto_schema(
+        operation_summary="카카오 로그인 콜백",
+        operation_description="ccode/state 검증 → 토큰 교환 → /v2/user/me 조회 → 세션 로그인 → FRONTEND_CALLBACK_URL로 302 리다이렉트 (?isNew=1|0).",
+        manual_parameters=[code_param, state_param, err_param, err_desc],
+        tags=["Auth"],
+        responses={302: "Redirect to / or /onboarding", 400: "Bad Request"},
+        security=[],
+    )
+    def get(self, request):
+
+        if request.GET.get("error"):
+            return Response({"detail": request.GET.get("error_description", "kakao error")}, status=400)
+
+        state = request.GET.get("state")
+        saved = request.session.get("kakao_oauth_state")
+        if not state or not saved or state != saved:
+            return Response({"detail": "invalid state"}, status=400)
+        request.session.pop("kakao_oauth_state", None)
+
+        code = request.GET.get("code")
+        if not code:
+            return Response({"detail": "missing code"}, status=400)
+
+        data = {
+            "grant_type": "authorization_code",
+            "client_id": settings.KAKAO_REST_API_KEY,
+            "redirect_uri": settings.KAKAO_REDIRECT_URI,
+            "code": code,
+        }
+        cs = getattr(settings, "KAKAO_CLIENT_SECRET", "")
+        if cs:
+            data["client_secret"] = cs
+
+        try:
+            token_res = requests.post(
+                "https://kauth.kakao.com/oauth/token",
+                headers={"Content-Type": "application/x-www-form-urlencoded;charset=utf-8"},
+                data=data,
+                timeout=5,
+            )
+            token_res.raise_for_status()
+            access_token = token_res.json()["access_token"]
+        except Exception as e:
+            return Response({"detail": f"token exchange failed: {e}"}, status=400)
+
+        try:
+            me_res = requests.get(
+                "https://kapi.kakao.com/v2/user/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=5,
+            )
+            me_res.raise_for_status()
+            kakao_id = str(me_res.json()["id"])
+        except Exception as e:
+            return Response({"detail": f"user info failed: {e}"}, status=400)
+
+        is_new = False
+        with transaction.atomic():
+            link = (SocialAccount.objects
+                    .select_related("user")
+                    .filter(provider="kakao", provider_user_id=kakao_id)
+                    .first())
+            if link:
+                user = link.user
+            else:
+                user, created = User.objects.get_or_create(
+                    handle=f"kakao_{kakao_id}",
+                )
+                if created:
+                    user.set_unusable_password()
+                    user.save()
+                SocialAccount.objects.get_or_create(
+                    user=user, provider="kakao", provider_user_id=kakao_id
+                )
+                is_new = created
+
+        login(request, user)
+        params = {"isNew": "1" if is_new else "0"}
+        return redirect(f"{settings.FRONTEND_CALLBACK_URL}?{urlencode(params)}")
+
+class MeView(APIView):
+    permission_classes = [IsAuthenticated]
+    def get(self, request):
+        handle = getattr(request.user, "handle", getattr(request.user, "username", None))
+        return Response({"id": request.user.id, "handle": handle})

--- a/config/settings.py
+++ b/config/settings.py
@@ -48,6 +48,8 @@ ALLOWED_HOSTS = ["localhost", "0.0.0.0","127.0.0.1"]
 SESSION_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_HTTPONLY = True
 
+FRONTEND_CALLBACK_URL = os.environ.get("FRONTEND_CALLBACK_URL", "http://localhost:5173//auth/callback")
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -64,6 +66,7 @@ INSTALLED_APPS = [
     'integrations',
     'daenggle',
     'accounts',
+    'members',
 ]
 
 MIDDLEWARE = [
@@ -157,6 +160,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+AUTH_USER_MODEL = "members.User"
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/

--- a/members/admin.py
+++ b/members/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/members/apps.py
+++ b/members/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MembersConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'members'

--- a/members/models.py
+++ b/members/models.py
@@ -1,0 +1,38 @@
+from django.db import models
+from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, BaseUserManager
+from django.utils import timezone
+
+class UserManager(BaseUserManager):
+    def create_user(self, handle: str, password=None, **extra):
+        if not handle:
+            raise ValueError("handle is required")
+        user = self.model(handle=handle, **extra)
+        if password:
+            user.set_password(password)
+        else:
+            user.set_unusable_password() 
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, handle: str, password, **extra):
+        extra.setdefault("is_staff", True)
+        extra.setdefault("is_superuser", True)
+        if not password:
+            raise ValueError("Superuser must have a password")
+        return self.create_user(handle, password, **extra)
+
+class User(AbstractBaseUser, PermissionsMixin):
+
+    handle = models.CharField(max_length=40, unique=True)  # 예: "kakao_123456789"
+
+    is_active = models.BooleanField(default=True)
+    is_staff = models.BooleanField(default=False)
+    date_joined = models.DateTimeField(default=timezone.now)
+
+    USERNAME_FIELD = "handle"
+    REQUIRED_FIELDS = []
+
+    objects = UserManager()
+
+    def __str__(self):
+        return self.handle

--- a/members/tests.py
+++ b/members/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/members/views.py
+++ b/members/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.


### PR DESCRIPTION
## 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
- 카카오 OAuth2 로그인 콜백 처리 API를 추가 및  신규 유저 자동가입 + 세션 로그인 구현
- 테스트용 세션 확인 API(/api/v1/auth/me) 추가

## 관련 Epic
epic: #14 

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #15 

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- GET /api/v1/auth/kakao/callback 구현
  - state 검증 → code→token 교환 → /v2/user/me로 kakao_id 조회
  - members.User(handle="kakao_{id}") get_or_create → accounts.SocialAccount 연결
  - login(request, user) 후 settings.FRONTEND_CALLBACK_URL 로 ?isNew= 리다이렉트
- GET /api/v1/auth/me 현재 세션 유저 반환(테스트용) 구현
